### PR TITLE
fix(seo): update site URL references to use siteUrl from site metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ module.exports = {
     title: `Vitau | Blog`,
     description: `Salud, nutrición, hábitos, cuidado personal y más maneras de ser la mejor versión de nosotros mismos.`,
     author: `Vitau Médical`,
-    siteUrl: `http://beta-blog.vitau.mx`,
+    siteUrl: `https://blog.vitau.mx`,
   },
   plugins: [
     {

--- a/src/components/seo/CategoryMeta.js
+++ b/src/components/seo/CategoryMeta.js
@@ -14,8 +14,8 @@ const CategoryMeta = ({ category }) => {
   `)
 
   const { name, slug, description, feature_image } = category
-  const { url } = data.site.siteMetadata
-  const canonical = `${url}/${slug}`
+  const { siteUrl } = data.site.siteMetadata
+  const canonical = `${siteUrl}/${slug}`
   const title = `${name} | Vitau Blog`
 
   return (

--- a/src/components/seo/PostMeta.js
+++ b/src/components/seo/PostMeta.js
@@ -21,9 +21,9 @@ const PostMeta = ({ post }) => {
     excerpt,
     feature_image,
   } = post
-  const { url } = data.site.siteMetadata
+  const { siteUrl } = data.site.siteMetadata
 
-  const canonical = `${url}/${slug}`
+  const canonical = `${siteUrl}/${slug}`
 
   return (
     <Helmet>

--- a/src/components/seo/SiteMeta.js
+++ b/src/components/seo/SiteMeta.js
@@ -23,22 +23,22 @@ const SiteMeta = () => {
   `)
 
   const { title, description, lang } = data.allGhostSettings.edges[0].node
-  const { url } = data.site
+  const { siteUrl } = data.site.siteMetadata
 
   return (
     <Helmet>
       <html lang={lang} />
       <title>{title}</title>
       <meta name="description" content={description} />
-      <link rel="canonical" href={url} />
+      <link rel="canonical" href={siteUrl} />
       <meta property="og:site_name" content={title} />
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:url" content={url} />
+      <meta property="og:url" content={siteUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:url" content={url} />
+      <meta name="twitter:url" content={siteUrl} />
       <link
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
         rel="stylesheet"


### PR DESCRIPTION
# Corrección de URLs canónicas para indexación en Google

Este PR corrige un problema crítico con la indexación de páginas del blog en Google. La URL canónica estaba siendo construida incorrectamente, causando redirecciones que impedían la indexación.

Cambios realizados:
1. Se actualizó la referencia correcta a `siteUrl` en los componentes SEO
2. Se corrigió la estructura de las URLs canónicas para evitar la generación de rutas con `/undefined/`
3. Se aseguró que todos los metadatos SEO apunten a las URLs correctas

Este cambio permitirá que Google indexe correctamente las páginas del blog.
